### PR TITLE
Update generated_cases.c.h.

### DIFF
--- a/Python/generated_cases.c.h
+++ b/Python/generated_cases.c.h
@@ -6839,7 +6839,7 @@
                 *value_ptr = PyStackRef_AsPyObjectSteal(value);
                 if (old_value == NULL) {
                     PyDictValues *values = _PyObject_InlineValues(owner_o);
-                    int index = value_ptr - values->values;
+                    Py_ssize_t index = value_ptr - values->values;
                     _PyDictValues_AddToInsertionOrder(values, index);
                 }
                 else {


### PR DESCRIPTION
Set `index` type to `Py_ssize_t` instead of `int`.
